### PR TITLE
Use iOS clients for playing music

### DIFF
--- a/app/src/main/kotlin/app/vitune/android/service/PlayerService.kt
+++ b/app/src/main/kotlin/app/vitune/android/service/PlayerService.kt
@@ -488,6 +488,17 @@ class PlayerService : InvincibleService(), Player.Listener, PlaybackStatsListene
 
         if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO || reason == Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
             updateMediaSessionQueue(player.currentTimeline)
+
+        // Add detailed logging for player-related errors
+        if (mediaItem != null) {
+            logcat().add(Logcat.FormattedLine(
+                timestamp = Instant.now(),
+                level = Logcat.FormattedLine.Level.Info,
+                tag = TAG,
+                pid = Process.myPid().toLong(),
+                message = "Media item transitioned: ${mediaItem.mediaId}"
+            ))
+        }
     }
 
     override fun onTimelineChanged(timeline: Timeline, reason: Int) {
@@ -526,6 +537,15 @@ class PlayerService : InvincibleService(), Player.Listener, PlaybackStatsListene
                 )
                 .setContentTitle(getString(R.string.skip_on_error))
         }
+
+        // Add detailed logging for player-related errors
+        logcat().add(Logcat.FormattedLine(
+            timestamp = Instant.now(),
+            level = Logcat.FormattedLine.Level.Error,
+            tag = TAG,
+            pid = Process.myPid().toLong(),
+            message = "Player error: ${error.message}"
+        ))
     }
 
     private fun updateMediaSessionQueue(timeline: Timeline) {

--- a/providers/innertube/src/main/kotlin/app/vitune/providers/innertube/models/Context.kt
+++ b/providers/innertube/src/main/kotlin/app/vitune/providers/innertube/models/Context.kt
@@ -81,17 +81,9 @@ data class Context(
         }
         const val DEFAULT_VISITOR_DATA = "CgtsZG1ySnZiQWtSbyiMjuGSBg%3D%3D"
 
-        val DefaultWeb get() = DefaultWebNoLang.withLang
+        val DefaultWeb get() = DefaultIOS.withLang
 
-        val DefaultWebNoLang = Context(
-            client = Client(
-                clientName = "WEB_REMIX",
-                clientVersion = "1.20220606.03.00",
-                platform = "DESKTOP",
-                userAgent = UserAgents.DESKTOP,
-                referer = "https://music.youtube.com/"
-            )
-        )
+        val DefaultWebNoLang = DefaultIOS
 
         val DefaultWebOld = Context(
             client = Client(


### PR DESCRIPTION
Update the app to use iOS hidden API clients for playing music and add deep logging for player-related errors.

* **Update API Clients**
  - Modify `providers/innertube/src/main/kotlin/app/vitune/providers/innertube/models/Context.kt` to use `DefaultIOS` context for `DefaultWeb` and `DefaultWebNoLang`.

* **Add Deep Logging**
  - Add detailed logging for player-related errors in `app/src/main/kotlin/app/vitune/android/service/PlayerService.kt` in `onPlayerError` and `onMediaItemTransition` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/guest3301/ViTune/pull/1?shareId=277cc81d-c5b6-4176-8672-626bdb54907f).